### PR TITLE
Fixed 'DUP' Flag mislocation for re-delivering QoS1 PUBLISH Packets

### DIFF
--- a/src/mqtt.c
+++ b/src/mqtt.c
@@ -481,13 +481,13 @@ mqtt_setMsgState(struct mqtt_client *client, LocalSendAll *local)
                 local->msg->state = MQTT_QUEUED_COMPLETE;
                 break;
             case MQTT_CONTROL_PUBLISH:
-                local->inspected = 0x03 & ((local->msg->start[0]) >> 1); /* qos */
+                local->inspected = ( MQTT_PUBLISH_QOS_MASK & (local->msg->start[0]) ) >> 1; /* qos */
                 if (local->inspected == 0) {
                     local->msg->state = MQTT_QUEUED_COMPLETE;
                 } else if (local->inspected == 1) {
                     local->msg->state = MQTT_QUEUED_AWAITING_ACK;
-                    /*set DUP flag for subsequent sends */ 
-                    local->msg->start[1] |= MQTT_PUBLISH_DUP;
+                    /*set DUP flag for subsequent sends [Spec MQTT-3.3.1-1] */
+                    local->msg->start[0] |= MQTT_PUBLISH_DUP;
                 } else {
                     local->msg->state = MQTT_QUEUED_AWAITING_ACK;
                 }
@@ -656,13 +656,13 @@ ssize_t __mqtt_send(struct mqtt_client *client)
             msg->state = MQTT_QUEUED_COMPLETE;
             break;
         case MQTT_CONTROL_PUBLISH:
-            inspected = 0x03 & ((msg->start[0]) >> 1); /* qos */
+            inspected = ( MQTT_PUBLISH_QOS_MASK & (msg->start[0]) ) >> 1; /* qos */
             if (inspected == 0) {
                 msg->state = MQTT_QUEUED_COMPLETE;
             } else if (inspected == 1) {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
-                /*set DUP flag for subsequent sends */ 
-                msg->start[1] |= MQTT_PUBLISH_DUP;
+                /*set DUP flag for subsequent sends [Spec MQTT-3.3.1-1] */
+                msg->start[0] |= MQTT_PUBLISH_DUP;
             } else {
                 msg->state = MQTT_QUEUED_AWAITING_ACK;
             }
@@ -1704,7 +1704,7 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
     }
 
     /* inspect QoS level */
-    inspected_qos = (publish_flags & 0x06) >> 1; /* mask */
+    inspected_qos = (publish_flags & MQTT_PUBLISH_QOS_MASK) >> 1; /* mask */
 
     /* build the fixed header */
     fixed_header.control_type = MQTT_CONTROL_PUBLISH;
@@ -1717,12 +1717,12 @@ ssize_t mqtt_pack_publish_request(uint8_t *buf, size_t bufsz,
     remaining_length += (uint16_t)application_message_size;
     fixed_header.remaining_length = remaining_length;
 
-    /* force dup to 0 if qos is 0 */
+    /* force dup to 0 if qos is 0 [Spec MQTT-3.3.1-2] */
     if (inspected_qos == 0) {
         publish_flags &= ~MQTT_PUBLISH_DUP;
     }
 
-    /* make sure that qos is not 3 */
+    /* make sure that qos is not 3 [Spec MQTT-3.3.1-4] */
     if (inspected_qos == 3) {
         return MQTT_ERROR_PUBLISH_FORBIDDEN_QOS;
     }
@@ -1767,7 +1767,7 @@ ssize_t mqtt_unpack_publish_response(struct mqtt_response *mqtt_response, const 
 
     /* get flags */
     response->dup_flag = (fixed_header->control_flags & MQTT_PUBLISH_DUP) >> 3;
-    response->qos_level = (fixed_header->control_flags & 0x06) >> 1;
+    response->qos_level = (fixed_header->control_flags & MQTT_PUBLISH_QOS_MASK) >> 1;
     response->retain_flag = fixed_header->control_flags & MQTT_PUBLISH_RETAIN;
 
     /* make sure that remaining length is valid */


### PR DESCRIPTION
Implemented changes to fix a bug, added some info and refactored a little to use a mask instead of a hardcoded value.